### PR TITLE
fix: use explicit fee rate in Contract.service.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yours-wallet",
-  "version": "4.5.2",
+  "version": "4.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yours-wallet",
-      "version": "4.5.2",
+      "version": "4.5.5",
       "dependencies": {
         "@bsv/paymail": "^2.0.2",
         "@bsv/sdk": "1.6.26",

--- a/src/initSPVStore.ts
+++ b/src/initSPVStore.ts
@@ -23,6 +23,7 @@ import { ChromeStorageService } from './services/ChromeStorage.service';
 import { sendMessage } from './utils/chromeHelpers';
 import { theme } from './theme';
 import { MNEE_DECIMALS, MNEE_ICON_ID, MNEE_SYM, MNEE_TOKEN_ID } from './utils/constants';
+import { ArcBroadcastService } from './services/ArcBroadcast.service';
 import { MNEEIndexer } from './utils/mneeIndexer';
 
 export const getIndexers = (owners: Set<string>, network: NetWork) => {
@@ -109,6 +110,11 @@ export const initOneSatSPV = async (chromeStorageService: ChromeStorageService, 
   );
 
   if (!oneSatSPV) throw Error('SPV not initialized!');
+
+  // Override the broadcast service to use ARC directly.
+  // The default OneSatProvider broadcasts via ordinals.1sat.app which is unreliable (502s).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (oneSatSPV as any).services.broadcast = new ArcBroadcastService();
 
   await registerEventListeners(oneSatSPV, selectedAccount || '', startSync);
 

--- a/src/services/ArcBroadcast.service.ts
+++ b/src/services/ArcBroadcast.service.ts
@@ -1,0 +1,78 @@
+import { type BroadcastResponse, type BroadcastFailure, Transaction } from '@bsv/sdk';
+import { GORILLA_POOL_ARC_URL, WOC_BASE_URL } from '../utils/constants';
+
+/**
+ * Broadcast service that sends transactions via GorillaPool ARC,
+ * with WoC as a fallback. Returns properly formatted BroadcastResponse/BroadcastFailure
+ * compatible with @bsv/sdk expectations.
+ */
+export class ArcBroadcastService {
+  async broadcast(tx: Transaction): Promise<BroadcastResponse | BroadcastFailure> {
+    const txHex = tx.toHex();
+    console.log('Broadcasting via ARC', tx.id('hex'));
+
+    // Try ARC first
+    try {
+      const response = await fetch(`${GORILLA_POOL_ARC_URL}/tx`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: Buffer.from(tx.toBinary()),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.txid) {
+          return { status: 'success', txid: data.txid, message: data.title || 'Broadcast successful' };
+        }
+      }
+
+      // ARC returned an error — try to parse it
+      let errorMsg = `ARC error ${response.status}`;
+      try {
+        const errData = await response.json();
+        errorMsg = errData.detail || errData.title || errorMsg;
+      } catch {
+        // Response wasn't JSON (e.g. HTML error page) — use status text
+        errorMsg = `ARC error ${response.status}: ${response.statusText}`;
+      }
+      console.warn('ARC broadcast failed:', errorMsg);
+
+      // Fall through to WoC fallback
+    } catch (err) {
+      console.warn('ARC broadcast request failed:', err);
+    }
+
+    // Fallback: try WoC
+    try {
+      console.log('Falling back to WoC broadcast');
+      const response = await fetch(`${WOC_BASE_URL}/tx/raw`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ txhex: txHex }),
+      });
+
+      if (response.ok) {
+        const txid = await response.json();
+        if (typeof txid === 'string' && txid.length === 64) {
+          return { status: 'success', txid, message: 'Broadcast successful via WoC' };
+        }
+      }
+
+      let errorMsg = `WoC error ${response.status}`;
+      try {
+        const errText = await response.text();
+        errorMsg = errText || errorMsg;
+      } catch {
+        // ignore
+      }
+
+      return { status: 'error', code: response.status.toString(), description: errorMsg };
+    } catch (err) {
+      return {
+        status: 'error',
+        code: 'NETWORK_ERROR',
+        description: `Broadcast failed: ${err instanceof Error ? err.message : 'unknown error'}`,
+      };
+    }
+  }
+}

--- a/src/services/Bsv.service.ts
+++ b/src/services/Bsv.service.ts
@@ -149,8 +149,8 @@ export class BsvService {
 
       await tx.sign();
       const response = await this.oneSatSPV.broadcast(tx);
-      console.log(`Transaction broadcast response: ${response}`);
-      if (response.status == 'error') return { error: response.description };
+      console.log('Transaction broadcast response:', response);
+      if (response.status == 'error') return { error: response.description || 'broadcast-error' };
       const txHex = tx.toHex();
       const chromeObj = this.chromeStorageService.getCurrentAccountObject();
       if (!chromeObj.account) return { error: 'no-account' };
@@ -287,6 +287,10 @@ export class BsvService {
       if (showPreview) return { rawtx: tx.toHex() };
 
       const response = await this.oneSatSPV.broadcast(tx);
+      if (response.status == 'error') {
+        console.error('Broadcast failed:', response);
+        return { error: response.description || 'broadcast-error' };
+      }
 
       const txHex = tx.toHex();
       const chromeObj = this.chromeStorageService.getCurrentAccountObject();
@@ -298,8 +302,6 @@ export class BsvService {
           note: `P2P tx from ${theme.settings.walletName}`,
         });
       }
-
-      if (response.status == 'error') return { error: response.description };
       if (isBelowNoApprovalLimit) {
         const { noApprovalLimit } = chromeObj.account.settings;
         const key: keyof ChromeStorageObject = 'accounts';

--- a/src/services/Contract.service.ts
+++ b/src/services/Contract.service.ts
@@ -1,7 +1,7 @@
 import { GetSignatures, SignatureResponse } from 'yours-wallet-provider';
-import { DEFAULT_SIGHASH_TYPE } from '../utils/constants';
+import { DEFAULT_SIGHASH_TYPE, FEE_PER_KB } from '../utils/constants';
 import { KeysService } from './Keys.service';
-import { Hash, P2PKH, PrivateKey, Script, Transaction, TransactionSignature, Utils } from '@bsv/sdk';
+import { Hash, P2PKH, PrivateKey, SatoshisPerKilobyte, Script, Transaction, TransactionSignature, Utils } from '@bsv/sdk';
 import { SPVStore, Txo } from 'spv-store';
 import { LockTemplate } from 'spv-store';
 export class ContractService {
@@ -136,7 +136,7 @@ export class ContractService {
         });
       }
 
-      await tx.fee();
+      await tx.fee(new SatoshisPerKilobyte(FEE_PER_KB));
       await tx.sign();
       const response = await this.oneSatSPV.broadcast(tx);
       if (response?.txid) {

--- a/src/services/Ordinal.service.ts
+++ b/src/services/Ordinal.service.ts
@@ -153,8 +153,9 @@ export class OrdinalService {
       await tx.sign();
 
       const response = await this.oneSatSPV.broadcast(tx);
-      if (response?.txid) {
-        return { txid: response.txid };
+      if (response.status === 'error') {
+        console.error('Broadcast failed:', response);
+        return { error: response.description || 'broadcast-failed' };
       }
 
       const txHex = tx.toHex();
@@ -168,7 +169,7 @@ export class OrdinalService {
         });
       }
 
-      return { error: 'broadcast-failed' };
+      return { txid: response.txid };
     } catch (error) {
       console.error('transferOrdinal failed:', error);
       return { error: JSON.stringify(error) };

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -91,6 +91,8 @@ export const getErrorMessage = (error: string | undefined) => {
       return 'Key type does not exist!';
 
     default:
+      // If the error is a descriptive string from ARC/broadcast, show it directly
+      if (error && error.length > 0) return error;
       return 'An unknown error has occurred! Try again.';
   }
 };


### PR DESCRIPTION
## Summary
- **Root cause**: `ordinals.1sat.app/v5/tx` broadcast endpoint returns 502 (Bad Gateway) with HTML error pages, and the JSON parser crashes on the HTML — breaking all sends
- Adds `ArcBroadcastService` that broadcasts via `arc.gorillapool.io` with WhatsOnChain as fallback, returning properly formatted `@bsv/sdk` `BroadcastResponse`/`BroadcastFailure` so SPV store UTXO ingestion continues to work
- Fixes `sendBsv` broadcast error check — was after paymail notification (errors got swallowed by paymail exceptions)
- Fixes `transferOrdinal` — paymail P2P notification was only sent on broadcast *failure* (reversed logic)
- Fixes `Contract.unlock` — was calling `tx.fee()` with no fee model (now uses `SatoshisPerKilobyte(FEE_PER_KB)`)
- Surfaces actual broadcast error descriptions to the user instead of "An unknown error has occurred"

## Test plan
- [x] Tested BSV send locally — broadcasts via ARC successfully
- [ ] Verify ordinal transfers work
- [ ] Verify BSV20 token sends work
- [ ] Verify lock/unlock works with new fee model

🤖 Generated with [Claude Code](https://claude.com/claude-code)