### PR TITLE
fix: remove axios dependency (supply chain attack mitigation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.2.7",
     "assert": "^2.1.0",
-    "axios": "^1.5.1",
     "bitcoin-address-validation": "^2.2.3",
     "browserify": "^17.0.0",
     "buffer": "^6.0.3",

--- a/src/api/faucet.ts
+++ b/src/api/faucet.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 const WITNESSONCHAIN_API_URL = 'https://witnessonchain.com/v1';
 
 interface FaucetResponse {
@@ -11,11 +9,13 @@ interface FaucetResponse {
 
 export async function requestTestnetCoins(address: string): Promise<FaucetResponse> {
   try {
-    const response = await axios.post<FaucetResponse>(`${WITNESSONCHAIN_API_URL}/faucet/tbsv`, {
-      address,
-      channel: 'yours-wallet',
+    const response = await fetch(`${WITNESSONCHAIN_API_URL}/faucet/tbsv`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address, channel: 'yours-wallet' }),
     });
-    return response.data;
+    if (!response.ok) throw new Error(`Faucet request failed: ${response.status}`);
+    return response.json() as Promise<FaucetResponse>;
   } catch (error) {
     console.error('Error requesting testnet coins:', error);
     throw error;

--- a/src/services/GorillaPool.service.ts
+++ b/src/services/GorillaPool.service.ts
@@ -32,7 +32,7 @@ export class GorillaPoolService {
           tokenId.length > 30 ? 'id' : 'tick'
         }=${tokenId}`,
       );
-      if (!res.ok) continue;
+      if (!res.ok) throw new Error(`Failed to fetch token price: ${res.status}`);
       const data = await res.json() as MarketResponse[];
       if (data.length > 0) {
         result.push({ id: tokenId, satPrice: data[0].pricePer });
@@ -98,7 +98,7 @@ export class GorillaPoolService {
             : `${this.getBaseUrl(network)}/api/bsv20/${address}/tick/${tick}?limit=10000`;
 
           const r = await fetch(url);
-          if (!r.ok) return;
+          if (!r.ok) throw new Error(`Failed to fetch BSV20 UTXOs: ${r.status}`);
           const rData = await r.json();
           (rData as BSV20Txo[]).forEach((utxo) => {
             if (utxo.status === 1 && !utxo.listing) utxos.push(utxo);

--- a/src/services/GorillaPool.service.ts
+++ b/src/services/GorillaPool.service.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { Bsv20, BSV20Txo, NetWork, Ordinal } from 'yours-wallet-provider';
 import { GP_BASE_URL, GP_TESTNET_BASE_URL } from '../utils/constants';
 import { MarketResponse, Token } from './types/gorillaPool.types';
@@ -14,8 +13,9 @@ export class GorillaPoolService {
   getUtxoByOutpoint = async (outpoint: string): Promise<Ordinal> => {
     try {
       const network = this.chromeStorageService.getNetwork();
-      const { data } = await axios.get(`${this.getBaseUrl(network)}/api/txos/${outpoint}?script=true`);
-      const ordUtxo: Ordinal = data;
+      const res = await fetch(`${this.getBaseUrl(network)}/api/txos/${outpoint}?script=true`);
+      if (!res.ok) throw new Error(`Failed to fetch outpoint: ${res.status}`);
+      const ordUtxo: Ordinal = await res.json();
       if (!ordUtxo.script) throw Error('No script when fetching by outpoint');
       return ordUtxo;
     } catch (e) {
@@ -27,11 +27,13 @@ export class GorillaPoolService {
     const network = this.chromeStorageService.getNetwork();
     const result: { id: string; satPrice: number }[] = [];
     for (const tokenId of tokenIds) {
-      const { data } = await axios.get<MarketResponse[]>(
+      const res = await fetch(
         `${this.getBaseUrl(network)}/api/bsv20/market?sort=price_per_token&dir=asc&limit=1&offset=0&${
           tokenId.length > 30 ? 'id' : 'tick'
         }=${tokenId}`,
       );
+      if (!res.ok) continue;
+      const data = await res.json() as MarketResponse[];
       if (data.length > 0) {
         result.push({ id: tokenId, satPrice: data[0].pricePer });
       }
@@ -42,9 +44,11 @@ export class GorillaPoolService {
   getBsv20Balances = async (addresses: string[]) => {
     const network = this.chromeStorageService.getNetwork();
     const url = `${this.getBaseUrl(network)}/api/bsv20/balance?addresses=${addresses.join('&addresses=')}`;
-    const res = await axios.get(url);
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Failed to fetch BSV20 balances: ${res.status}`);
+    const resData = await res.json();
 
-    const bsv20List: Array<Bsv20> = res.data.map(
+    const bsv20List: Array<Bsv20> = resData.map(
       (b: {
         all: {
           confirmed: string;
@@ -93,8 +97,10 @@ export class GorillaPoolService {
             ? `${this.getBaseUrl(network)}/api/bsv20/${address}/id/${tick}?limit=10000`
             : `${this.getBaseUrl(network)}/api/bsv20/${address}/tick/${tick}?limit=10000`;
 
-          const r = await axios.get(url);
-          (r.data as BSV20Txo[]).forEach((utxo) => {
+          const r = await fetch(url);
+          if (!r.ok) return;
+          const rData = await r.json();
+          (rData as BSV20Txo[]).forEach((utxo) => {
             if (utxo.status === 1 && !utxo.listing) utxos.push(utxo);
           });
         }),
@@ -114,9 +120,9 @@ export class GorillaPoolService {
         ? `${this.getBaseUrl(network)}/api/bsv20/id/${tick}`
         : `${this.getBaseUrl(network)}/api/bsv20/tick/${tick}`;
 
-      const r = await axios.get<Token>(url);
-
-      return r.data;
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`Failed to fetch BSV20 details: ${r.status}`);
+      return await r.json() as Token;
     } catch (error) {
       console.error('getBsv20Details', error);
     }

--- a/src/services/Keys.service.ts
+++ b/src/services/Keys.service.ts
@@ -162,7 +162,8 @@ export class KeysService {
       if (!res.ok) throw new Error(`WoC request failed: ${res.status}`);
       const utxos = await res.json() as WocUtxo[];
       if (utxos.length === 0) return 0;
-      return utxos.reduce((acc, u) => acc + u.value, 0);
+      const balance = utxos.reduce((acc, u) => acc + u.value, 0);
+      return balance;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       console.log(error);

--- a/src/services/Keys.service.ts
+++ b/src/services/Keys.service.ts
@@ -17,7 +17,6 @@ import { SupportedWalletImports, WifKeys } from './types/keys.types';
 import { P2PKH, PrivateKey, SatoshisPerKilobyte, Transaction, Utils } from '@bsv/sdk';
 import { SPVStore } from 'spv-store';
 import { WocUtxo } from './types/whatsOnChain.types';
-import axios from 'axios';
 
 export class KeysService {
   bsvAddress: string;
@@ -130,8 +129,9 @@ export class KeysService {
       const outScript = new P2PKH().lock(keys.walletAddress);
       tx.addOutput({ lockingScript: outScript, change: true });
 
-      const { data } = await axios.get<WocUtxo[]>(`${WOC_BASE_URL}/address/${sweepWallet.address}/unspent`);
-      const utxos = data;
+      const res = await fetch(`${WOC_BASE_URL}/address/${sweepWallet.address}/unspent`);
+      if (!res.ok) throw new Error(`WoC request failed: ${res.status}`);
+      const utxos = await res.json() as WocUtxo[];
       if (utxos.length === 0) return;
       const feeModel = new SatoshisPerKilobyte(this.chromeStorageService.getCustomFeeRate());
       for await (const u of utxos || []) {
@@ -158,11 +158,11 @@ export class KeysService {
   getWifBalance = async (wif: string) => {
     try {
       const privKey = PrivateKey.fromWif(wif);
-      const { data } = await axios.get<WocUtxo[]>(`${WOC_BASE_URL}/address/${privKey.toAddress()}/unspent`);
-      const utxos = data;
+      const res = await fetch(`${WOC_BASE_URL}/address/${privKey.toAddress()}/unspent`);
+      if (!res.ok) throw new Error(`WoC request failed: ${res.status}`);
+      const utxos = await res.json() as WocUtxo[];
       if (utxos.length === 0) return 0;
-      const balance = utxos.reduce((acc, u) => acc + u.value, 0);
-      return balance;
+      return utxos.reduce((acc, u) => acc + u.value, 0);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       console.log(error);
@@ -177,8 +177,9 @@ export class KeysService {
       const outScript = new P2PKH().lock(this.bsvAddress);
       tx.addOutput({ lockingScript: outScript, change: true });
 
-      const { data } = await axios.get<WocUtxo[]>(`${WOC_BASE_URL}/address/${privKey.toAddress()}/unspent`);
-      const utxos = data;
+      const res = await fetch(`${WOC_BASE_URL}/address/${privKey.toAddress()}/unspent`);
+      if (!res.ok) throw new Error(`WoC request failed: ${res.status}`);
+      const utxos = await res.json() as WocUtxo[];
       if (utxos.length === 0) return;
       const feeModel = new SatoshisPerKilobyte(this.chromeStorageService.getCustomFeeRate());
       for await (const u of utxos || []) {

--- a/src/services/WhatsOnChain.service.ts
+++ b/src/services/WhatsOnChain.service.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { NetWork } from 'yours-wallet-provider';
 import { WOC_BASE_URL, WOC_TESTNET_BASE_URL } from '../utils/constants';
 import { ChromeStorageService } from './ChromeStorage.service';
@@ -28,12 +27,11 @@ export class WhatsOnChainService {
       if (exchangeRateCache?.rate && Date.now() - exchangeRateCache.timestamp < 5 * 60 * 1000) {
         return Number(exchangeRateCache.rate.toFixed(2));
       } else {
-        const res = await axios.get(`${this.getBaseUrl(network)}/exchangerate`, this.config);
-        if (!res.data) {
-          throw new Error('Could not fetch exchange rate from WOC!');
-        }
+        const res = await fetch(`${this.getBaseUrl(network)}/exchangerate`, { headers: this.config.headers });
+        if (!res.ok) throw new Error('Could not fetch exchange rate from WOC!');
+        const data = await res.json();
 
-        const rate = Number(res.data.rate.toFixed(2));
+        const rate = Number(data.rate.toFixed(2));
         const currentTime = Date.now();
         await this.chromeStorageService.update({ exchangeRateCache: { rate, timestamp: currentTime } });
         return rate;
@@ -46,8 +44,9 @@ export class WhatsOnChainService {
   getRawTxById = async (txid: string): Promise<string | undefined> => {
     try {
       const network = this.chromeStorageService.getNetwork();
-      const { data } = await axios.get(`${this.getBaseUrl(network)}/tx/${txid}/hex`, this.config);
-      return data;
+      const res = await fetch(`${this.getBaseUrl(network)}/tx/${txid}/hex`, { headers: this.config.headers });
+      if (!res.ok) throw new Error(`Failed to get raw tx: ${res.status}`);
+      return res.text();
     } catch (error) {
       console.log(error);
     }
@@ -56,15 +55,19 @@ export class WhatsOnChainService {
   broadcastRawTx = async (txhex: string): Promise<string | undefined> => {
     try {
       const network = this.chromeStorageService.getNetwork();
-      const { data: txid } = await axios.post(`${this.getBaseUrl(network)}/tx/raw`, { txhex }, this.config);
-      return txid;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        // Access to config, request, and response
-        console.error('broadcast rawtx failed:', error.response.data);
-      } else {
-        console.error('broadcast rawtx failed:', error);
+      const res = await fetch(`${this.getBaseUrl(network)}/tx/raw`, {
+        method: 'POST',
+        headers: { ...this.config.headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ txhex }),
+      });
+      if (!res.ok) {
+        const errorBody = await res.text().catch(() => 'unknown');
+        console.error('broadcast rawtx failed:', errorBody);
+        return;
       }
+      return res.json();
+    } catch (error) {
+      console.error('broadcast rawtx failed:', error);
     }
   };
 
@@ -97,8 +100,9 @@ export class WhatsOnChainService {
   getChainInfo = async (): Promise<ChainInfo | undefined> => {
     try {
       const network = this.chromeStorageService.getNetwork();
-      const { data } = await axios.get(`${this.getBaseUrl(network)}/chain/info`, this.config);
-      return data as ChainInfo;
+      const res = await fetch(`${this.getBaseUrl(network)}/chain/info`, { headers: this.config.headers });
+      if (!res.ok) throw new Error(`Failed to get chain info: ${res.status}`);
+      return await res.json() as ChainInfo;
     } catch (error) {
       console.log(error);
     }

--- a/src/utils/mneeIndexer.ts
+++ b/src/utils/mneeIndexer.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { Indexer, Ingest, ParseMode, TxoStore } from 'spv-store';
 import { MNEE_API, MNEE_API_TOKEN } from './constants';
 
@@ -21,7 +20,13 @@ export class MNEEIndexer extends Indexer {
 
   async sync(txoStore: TxoStore, ingestQueue: { [txid: string]: Ingest }): Promise<number> {
     if (this.network !== 'mainnet') return 0;
-    const { data } = await axios.post<TxResult[]>(`${MNEE_API}/v1/sync?auth_token=${MNEE_API_TOKEN}`, [...this.owners]);
+    const response = await fetch(`${MNEE_API}/v1/sync?auth_token=${MNEE_API_TOKEN}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([...this.owners]),
+    });
+    if (!response.ok) throw new Error(`MNEE sync failed: ${response.status}`);
+    const data = await response.json() as TxResult[];
     console.log('Syncing', data.length, 'mnee for ', [...txoStore.owners]);
     let maxScore = 0;
     for (const d of data) {


### PR DESCRIPTION
## Summary
- Removes `axios` from all source files and `package.json`
- Replaces with native `fetch` across 5 service files:
  - `src/api/faucet.ts`
  - `src/utils/mneeIndexer.ts`
  - `src/services/Keys.service.ts`
  - `src/services/WhatsOnChain.service.ts`
  - `src/services/GorillaPool.service.ts`
- Mitigates active supply chain attack on axios@1.14.1

## Test plan
- [ ] Exchange rate fetching still works
- [ ] Broadcast transactions via WoC
- [ ] BSV20 balance/token lookups via GorillaPool
- [ ] MNEE sync
- [ ] Faucet requests on testnet
- [ ] WIF sweep/balance check