### PR TITLE
Fix MNEE balance/history only reflecting the currently selected address

### DIFF
--- a/src/pages/BsvWallet.tsx
+++ b/src/pages/BsvWallet.tsx
@@ -130,6 +130,9 @@ export const BsvWallet = () => {
   // Get identityAddress from chrome storage (selected account)
   const identityAddress = chromeStorageService.getCurrentAccountObject().account?.addresses?.identityAddress || '';
   const [receiveAddress, setReceiveAddress] = useState<string>('');
+  // All derived MNEE deposit addresses for the account (not just the currently selected
+  // receiveAddress), used so MNEE balance/history aggregate deposits made to any address.
+  const [mneeAddresses, setMneeAddresses] = useState<string[]>([]);
   const [depositAddresses, setDepositAddresses] = useState<
     { address: string; index: number; derivationPrefix: string; derivationSuffix: string }[]
   >([]);
@@ -248,10 +251,70 @@ export const BsvWallet = () => {
     return { totalBsv, totalUsd };
   };
 
+  // BIP44-style gap limit for MNEE address discovery. `settings.maxKeyIndex` only advances
+  // when the user clicks "+ New Address" in this browser session, so a restored wallet (or one
+  // used across multiple devices) has no local record of higher indices that were previously
+  // funded elsewhere. Rather than deriving/checking unbounded addresses, probe ahead in bounded
+  // batches and stop as soon as a full batch comes back with no MNEE activity — mirrors standard
+  // HD wallet address-discovery behavior instead of scanning indefinitely.
+  const MNEE_GAP_LIMIT = 20;
+  const MNEE_MAX_GAP_SCANS = 10; // hard cap: at most 200 addresses probed ahead per call
+
+  /** Extend and persist maxKeyIndex if any higher, not-yet-tracked address has an MNEE balance. */
+  const discoverMneeMaxKeyIndex = async (knownMaxKeyIndex: number): Promise<number> => {
+    if (!apiContext) return knownMaxKeyIndex;
+    let maxKeyIndex = knownMaxKeyIndex;
+    let scanStart = knownMaxKeyIndex + 1;
+
+    for (let scan = 0; scan < MNEE_MAX_GAP_SCANS; scan++) {
+      const { derivations } = await deriveDepositAddresses.execute(apiContext, {
+        startIndex: scanStart,
+        count: MNEE_GAP_LIMIT,
+      });
+      const batchAddresses = derivations.map((d) => d.address);
+      const res = await getMneeBalance.execute(apiContext, { addresses: batchAddresses });
+      const fundedIndices = (res.balances ?? [])
+        .filter((b) => b.decimalAmount > 0)
+        .map((b) => batchAddresses.indexOf(b.address))
+        .filter((i) => i >= 0)
+        .map((i) => scanStart + i);
+
+      if (fundedIndices.length === 0) break; // full gap with no activity — stop probing
+
+      maxKeyIndex = Math.max(maxKeyIndex, ...fundedIndices);
+      scanStart += MNEE_GAP_LIMIT;
+    }
+
+    if (maxKeyIndex > knownMaxKeyIndex) {
+      const { account } = chromeStorageService.getCurrentAccountObject();
+      if (account) {
+        await chromeStorageService.updateNested('accounts', {
+          [identityAddress]: { settings: { ...account.settings, maxKeyIndex } } as unknown as Account,
+        });
+      }
+    }
+
+    return maxKeyIndex;
+  };
+
   const updateMneeBalance = async () => {
     if (!receiveAddress || !apiContext) return;
     try {
-      const res = await getMneeBalance.execute(apiContext, { addresses: [receiveAddress] });
+      // Aggregate MNEE balance across all derived deposit addresses for this account,
+      // not just the currently selected receive address, since MNEE can be deposited
+      // to any previously derived address.
+      const { account: acctForMnee } = chromeStorageService.getCurrentAccountObject();
+      const knownMaxKeyIndex = acctForMnee?.settings?.maxKeyIndex ?? 4; // default: 0-4 = 5 addresses
+      const maxKeyIndex = await discoverMneeMaxKeyIndex(knownMaxKeyIndex);
+      const { derivations } = await deriveDepositAddresses.execute(apiContext, {
+        startIndex: 0,
+        count: maxKeyIndex + 1,
+      });
+      const addresses = derivations.map((d) => d.address);
+      setMneeAddresses(addresses.length ? addresses : [receiveAddress]);
+      const res = await getMneeBalance.execute(apiContext, {
+        addresses: addresses.length ? addresses : [receiveAddress],
+      });
       setMneeBalance(res.totalDecimal);
 
       // Update MNEE balance in Chrome storage
@@ -1494,7 +1557,7 @@ export const BsvWallet = () => {
       </motion.button>
 
       <CoinHistory
-        filter={{ type: 'mnee', addresses: receiveAddress ? [receiveAddress] : [] }}
+        filter={{ type: 'mnee', addresses: mneeAddresses.length ? mneeAddresses : receiveAddress ? [receiveAddress] : [] }}
         refreshKey={mneeHistoryRefreshKey}
       />
     </motion.div>


### PR DESCRIPTION
### Summary

- MNEE balance and transaction history in the wallet UI only reflected the currently selected receive address, not the account as a whole.
- Depositing MNEE to a different address within the same account (e.g. one generated via "+ New Address") made those funds effectively disappear from the displayed total until the user manually switched back to that address.

### What changed

- BsvWallet.tsx
  - `updateMneeBalance()` now derives every address from index `0` to `maxKeyIndex` and calls `getMneeBalance` with the full list, instead of `[receiveAddress]` only.
  - Added `discoverMneeMaxKeyIndex()`: a bounded, BIP44-style gap-limit scan (batches of 20 addresses, capped at 10 batches / 200 addresses) that probes ahead for MNEE activity on addresses beyond the locally known `maxKeyIndex` and persists any extension found. This is needed because `settings.maxKeyIndex` only advances when "+ New Address" is clicked in that browser session — a restored wallet or one used across multiple devices has no local record of higher indices that were funded elsewhere.
  - The MNEE `CoinHistory` filter now uses the same full address set (`mneeAddresses`) instead of just `receiveAddress`, so transaction history is no longer scoped to a single address.

### Why not just derive unbounded addresses?

Scanning arbitrarily many addresses isn't feasible. Gap-limit scanning is the standard approach HD wallets use for address discovery on restore: probe ahead in bounded batches and stop once a full batch shows no activity. Known limitation: an address funded further out than the gap limit (20) beyond the last known used index won't be auto-discovered — same limitation as most BIP44 wallets.

### How to test

1. `bun run build` and load build unpacked in `chrome://extensions/` (dev mode).
2. From the Receive view, generate 2+ deposit addresses via "+ New Address".
3. Send MNEE to a non-primary/non-selected address.
4. Confirm the total MNEE balance on the main wallet view includes it without switching the selected address.
5. Confirm the MNEE transaction history list also shows the deposit.
6. Restore/re-import a wallet that has MNEE funded on an address beyond the default 5 (index 5+) and confirm it's picked up automatically.
